### PR TITLE
Adopt disbursement query for All Loans report

### DIFF
--- a/backend/lib/static_data.php
+++ b/backend/lib/static_data.php
@@ -6,8 +6,36 @@ if (!function_exists('getStaticDisbursements')) {
     function getStaticDisbursements(): array
     {
         return [
-            ['id' => 5001, 'application_id' => 1001, 'date' => '2024-03-05', 'amount' => 5000.0],
-            ['id' => 5002, 'application_id' => 1002, 'date' => '2024-04-20', 'amount' => 12000.0],
+            [
+                'id' => 5001,
+                'application_id' => 2001,
+                'date' => '2024-03-05',
+                'amount' => 5000.0,
+                'account_number' => 'LN-2024-001',
+                'remarks' => 'On track with repayments.',
+                'status' => 'Active',
+                'installment_count' => 12,
+            ],
+            [
+                'id' => 5002,
+                'application_id' => 2002,
+                'date' => '2024-04-20',
+                'amount' => 12000.0,
+                'account_number' => 'LN-2024-002',
+                'remarks' => 'Eligible for top up review.',
+                'status' => 'Active',
+                'installment_count' => 18,
+            ],
+            [
+                'id' => 5003,
+                'application_id' => 2003,
+                'date' => '2024-05-12',
+                'amount' => 8000.0,
+                'account_number' => 'LN-2024-003',
+                'remarks' => 'Watch late fees.',
+                'status' => 'In arrears',
+                'installment_count' => 15,
+            ],
         ];
     }
 }
@@ -16,8 +44,74 @@ if (!function_exists('getStaticRepayments')) {
     function getStaticRepayments(): array
     {
         return [
-            ['id' => 8001, 'application_id' => 1001, 'date' => '2024-04-04', 'amount' => 2600.0, 'principal' => 2500.0, 'interest' => 100.0],
-            ['id' => 8002, 'application_id' => 1002, 'date' => '2024-05-19', 'amount' => 6100.0, 'principal' => 6000.0, 'interest' => 100.0],
+            [
+                'id' => 8001,
+                'disbursement_id' => 5001,
+                'date' => '2024-04-04',
+                'amount' => 2600.0,
+                'principal' => 2500.0,
+                'interest' => 80.0,
+                'legal_fee' => 0.0,
+                'acceptance_fee' => 20.0,
+                'contract_variation_fee' => 0.0,
+                'cheque_dishonoured_fee' => 0.0,
+                'termination_fee' => 0.0,
+                'renewal_fee' => 0.0,
+                'late_fee' => 0.0,
+                'cheque_dishonour' => '0',
+                'deleted' => 0,
+            ],
+            [
+                'id' => 8002,
+                'disbursement_id' => 5001,
+                'date' => '2024-05-04',
+                'amount' => 2600.0,
+                'principal' => 2500.0,
+                'interest' => 80.0,
+                'legal_fee' => 0.0,
+                'acceptance_fee' => 0.0,
+                'contract_variation_fee' => 0.0,
+                'cheque_dishonoured_fee' => 0.0,
+                'termination_fee' => 0.0,
+                'renewal_fee' => 0.0,
+                'late_fee' => 0.0,
+                'cheque_dishonour' => '0',
+                'deleted' => 0,
+            ],
+            [
+                'id' => 8003,
+                'disbursement_id' => 5002,
+                'date' => '2024-05-19',
+                'amount' => 6100.0,
+                'principal' => 6000.0,
+                'interest' => 90.0,
+                'legal_fee' => 0.0,
+                'acceptance_fee' => 10.0,
+                'contract_variation_fee' => 0.0,
+                'cheque_dishonoured_fee' => 0.0,
+                'termination_fee' => 0.0,
+                'renewal_fee' => 0.0,
+                'late_fee' => 0.0,
+                'cheque_dishonour' => '0',
+                'deleted' => 0,
+            ],
+            [
+                'id' => 8004,
+                'disbursement_id' => 5003,
+                'date' => '2024-06-10',
+                'amount' => 0.0,
+                'principal' => 0.0,
+                'interest' => 0.0,
+                'legal_fee' => 0.0,
+                'acceptance_fee' => 0.0,
+                'contract_variation_fee' => 0.0,
+                'cheque_dishonoured_fee' => 0.0,
+                'termination_fee' => 0.0,
+                'renewal_fee' => 0.0,
+                'late_fee' => 45.0,
+                'cheque_dishonour' => '0',
+                'deleted' => 0,
+            ],
         ];
     }
 }
@@ -26,9 +120,78 @@ if (!function_exists('getStaticPaymentSchedules')) {
     function getStaticPaymentSchedules(): array
     {
         return [
-            ['id' => 7001, 'application_id' => 1001, 'date' => '2024-04-05', 'amount' => 2600.0, 'skip' => 0, 'deleted' => 0],
-            ['id' => 7002, 'application_id' => 1001, 'date' => '2024-05-05', 'amount' => 2600.0, 'skip' => 0, 'deleted' => 0],
-            ['id' => 7003, 'application_id' => 1002, 'date' => '2024-05-20', 'amount' => 6100.0, 'skip' => 0, 'deleted' => 0],
+            ['id' => 7001, 'disbursement_id' => 5001, 'date' => '2024-04-05', 'amount' => 2600.0, 'skip' => 0, 'deleted' => 0, 'interest' => 160.0],
+            ['id' => 7002, 'disbursement_id' => 5001, 'date' => '2024-05-05', 'amount' => 2600.0, 'skip' => 0, 'deleted' => 0, 'interest' => 160.0],
+            ['id' => 7003, 'disbursement_id' => 5002, 'date' => '2024-05-20', 'amount' => 6100.0, 'skip' => 0, 'deleted' => 0, 'interest' => 240.0],
+            ['id' => 7004, 'disbursement_id' => 5002, 'date' => '2024-06-20', 'amount' => 6100.0, 'skip' => 0, 'deleted' => 0, 'interest' => 240.0],
+            ['id' => 7005, 'disbursement_id' => 5003, 'date' => '2024-06-12', 'amount' => 3200.0, 'skip' => 0, 'deleted' => 0, 'interest' => 210.0],
+        ];
+    }
+}
+
+if (!function_exists('getStaticBorrowers')) {
+    function getStaticBorrowers(): array
+    {
+        return [
+            [
+                'id' => 1001,
+                'uid' => 'S9012345A',
+                'name' => 'Alicia Tan',
+                'gender' => 'Female',
+                'dob' => '1990-04-14',
+                'annual_income' => 62000.0,
+                'blk' => '123',
+                'street' => 'Serangoon Ave 3',
+                'unit' => '05-12',
+                'building' => 'Golden Court',
+                'pincode' => '550123',
+                'address1' => '123 Serangoon Ave 3',
+                'email' => 'alicia.tan@example.com',
+                'hand_phone' => '+65 8123 4567',
+            ],
+            [
+                'id' => 1002,
+                'uid' => 'S8912345B',
+                'name' => 'Benjamin Singh',
+                'gender' => 'Male',
+                'dob' => '1989-08-02',
+                'annual_income' => 78000.0,
+                'blk' => '88',
+                'street' => 'Bedok North St 4',
+                'unit' => '12-21',
+                'building' => 'Vista Towers',
+                'pincode' => '460088',
+                'address1' => '88 Bedok North St 4',
+                'email' => 'ben.singh@example.com',
+                'hand_phone' => '+65 8234 5678',
+            ],
+            [
+                'id' => 1003,
+                'uid' => 'S9001234C',
+                'name' => 'Celine Koh',
+                'gender' => 'Female',
+                'dob' => '1992-01-26',
+                'annual_income' => 54000.0,
+                'blk' => '18',
+                'street' => 'Jurong West Ave 1',
+                'unit' => '03-08',
+                'building' => 'Lakefront Residences',
+                'pincode' => '640018',
+                'address1' => '18 Jurong West Ave 1',
+                'email' => 'celine.koh@example.com',
+                'hand_phone' => '+65 8345 6789',
+            ],
+        ];
+    }
+}
+
+if (!function_exists('getStaticApplications')) {
+    function getStaticApplications(): array
+    {
+        return [
+            ['id' => 2001, 'borrower_id' => 1001, 'date' => '2024-03-01', 'amount' => 5000.0, 'deleted' => 0, 'account_number' => 'APP-2024-001'],
+            ['id' => 2002, 'borrower_id' => 1002, 'date' => '2024-04-15', 'amount' => 12000.0, 'deleted' => 0, 'account_number' => 'APP-2024-002'],
+            ['id' => 2003, 'borrower_id' => 1003, 'date' => '2024-05-08', 'amount' => 8000.0, 'deleted' => 0, 'account_number' => 'APP-2024-003'],
         ];
     }
 }

--- a/backend/reports/all-loans-report.php
+++ b/backend/reports/all-loans-report.php
@@ -1,0 +1,793 @@
+<?php
+
+declare(strict_types=1);
+
+header('Content-Type: text/html; charset=utf-8');
+
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../lib/static_data.php';
+
+$filters = [
+    'startDate' => getDateParam('startDate'),
+    'endDate' => getDateParam('endDate'),
+];
+
+$startDate = $filters['startDate'] ?? '1900-01-01';
+$endDate = $filters['endDate'] ?? '2100-12-31';
+
+$errorMessage = null;
+
+try {
+    $pdo = Database::tryConnect();
+    if ($pdo instanceof PDO) {
+        $rows = fetchLoanDetails($pdo, $startDate, $endDate);
+    } else {
+        $rows = buildStaticLoanDetails($startDate, $endDate);
+        $errorMessage = 'Database connection unavailable.';
+    }
+} catch (Throwable $exception) {
+    $errorMessage = 'Unexpected error while loading data.';
+    $rows = buildStaticLoanDetails($startDate, $endDate);
+}
+
+$loanCount = count($rows);
+$totalAmount = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['loan_amount'], 0.0);
+$totalPaidPrincipal = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['paid_principal'], 0.0);
+$totalOutstandingPrincipal = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['os_principal'], 0.0);
+$totalOutstandingInterest = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['os_interest'], 0.0);
+$totalInterestCollected = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['interest_collected'], 0.0);
+$totalProfit = array_reduce($rows, static fn (float $carry, array $row): float => $carry + (float) $row['profit'], 0.0);
+$uniqueBorrowers = count(array_unique(array_filter(
+    array_map(
+        static fn (array $row): string => (string) ($row['borrower_uid'] ?? ($row['borrower_id'] ?? '')),
+        $rows
+    ),
+    static fn (string $value): bool => $value !== ''
+)));
+
+$startLabel = $filters['startDate'] ? formatDisplayDate($filters['startDate']) : 'Earliest available';
+$endLabel = $filters['endDate'] ? formatDisplayDate($filters['endDate']) : 'Latest available';
+
+function getDateParam(string $key): ?string
+{
+    $value = $_GET[$key] ?? null;
+    if ($value === null || $value === '') {
+        return null;
+    }
+
+    $date = DateTime::createFromFormat('Y-m-d', $value);
+    return $date instanceof DateTime ? $date->format('Y-m-d') : null;
+}
+
+function fetchLoanDetails(PDO $pdo, string $startDate, string $endDate): array
+{
+    $sql = <<<SQL
+        SELECT
+            d.id AS disbursement_id,
+            ap.id AS application_id,
+            ap.borrower_id,
+            b.uid,
+            b.name AS borrower,
+            b.gender,
+            b.dob,
+            b.annual_income AS income,
+            b.blk AS block,
+            b.street,
+            b.unit AS unit_no,
+            b.building,
+            b.pincode AS postal,
+            b.address1 AS address,
+            b.email AS borrower_email,
+            b.hand_phone AS borrower_phone,
+            d.account_number,
+            d.date AS loan_date,
+            d.amount AS loan_amount,
+            d.remarks,
+            d.status,
+            d.installment_count AS tenure,
+            (
+                SELECT COALESCE(SUM(principal), 0)
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND cheque_dishonour != '1'
+                    AND deleted = 0
+            ) AS paid_principal,
+            d.amount - (
+                SELECT COALESCE(SUM(principal), 0)
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND cheque_dishonour != '1'
+                    AND deleted = 0
+            ) AS os_principal,
+            (
+                SELECT COALESCE(SUM(interest), 0)
+                FROM payment_schedule
+                WHERE disbursement_id = d.id
+                    AND deleted = 0
+            ) - (
+                SELECT COALESCE(SUM(interest), 0)
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND cheque_dishonour != '1'
+                    AND deleted = 0
+            ) AS os_interest,
+            (
+                SELECT COALESCE(SUM(r.amount), 0)
+                FROM repayments r
+                WHERE r.disbursement_id = d.id
+                    AND r.cheque_dishonour != '1'
+                    AND r.deleted = 0
+            ) - d.amount AS profit,
+            (
+                SELECT COALESCE(SUM(interest), 0)
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND cheque_dishonour != '1'
+                    AND deleted = 0
+            ) AS interest_collected,
+            (
+                SELECT COALESCE(SUM(legal_fee + acceptance_fee + contract_variation_fee + cheque_dishonoured_fee + termination_fee + renewal_fee + late_fee), 0)
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND cheque_dishonour != '1'
+                    AND deleted = 0
+            ) AS permit_fee_collected,
+            (
+                SELECT date
+                FROM repayments
+                WHERE disbursement_id = d.id
+                    AND deleted = 0
+                ORDER BY date DESC
+                LIMIT 1
+            ) AS last_paid_date
+        FROM disbursements d
+        LEFT JOIN applications ap ON d.application_id = ap.id
+        LEFT JOIN borrowers b ON ap.borrower_id = b.id
+        WHERE ap.deleted = 0
+            AND d.date BETWEEN :startDate AND :endDate
+        ORDER BY d.date DESC, d.id DESC
+    SQL;
+
+    $statement = $pdo->prepare($sql);
+    $statement->execute([
+        'startDate' => $startDate,
+        'endDate' => $endDate,
+    ]);
+
+    $results = [];
+
+    while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+        $results[] = [
+            'disbursement_id' => (int) ($row['disbursement_id'] ?? 0),
+            'application_id' => $row['application_id'] !== null ? (int) $row['application_id'] : null,
+            'borrower_id' => $row['borrower_id'] !== null ? (int) $row['borrower_id'] : null,
+            'borrower_uid' => $row['uid'] ?? null,
+            'borrower_name' => $row['borrower'] ?? 'Unknown borrower',
+            'gender' => $row['gender'] ?? null,
+            'dob' => $row['dob'] ?? null,
+            'annual_income' => (float) ($row['income'] ?? 0.0),
+            'block' => $row['block'] ?? null,
+            'street' => $row['street'] ?? null,
+            'unit_no' => $row['unit_no'] ?? null,
+            'building' => $row['building'] ?? null,
+            'postal' => $row['postal'] ?? null,
+            'address' => $row['address'] ?? null,
+            'borrower_email' => $row['borrower_email'] ?? null,
+            'borrower_phone' => $row['borrower_phone'] ?? null,
+            'account_number' => $row['account_number'] ?? null,
+            'loan_date' => $row['loan_date'] ?? null,
+            'loan_amount' => (float) ($row['loan_amount'] ?? 0.0),
+            'remarks' => $row['remarks'] ?? null,
+            'status' => $row['status'] ?? null,
+            'tenure' => $row['tenure'] !== null ? (int) $row['tenure'] : null,
+            'paid_principal' => (float) ($row['paid_principal'] ?? 0.0),
+            'os_principal' => (float) ($row['os_principal'] ?? 0.0),
+            'os_interest' => (float) ($row['os_interest'] ?? 0.0),
+            'profit' => (float) ($row['profit'] ?? 0.0),
+            'interest_collected' => (float) ($row['interest_collected'] ?? 0.0),
+            'permit_fee_collected' => (float) ($row['permit_fee_collected'] ?? 0.0),
+            'last_paid_date' => $row['last_paid_date'] ?? null,
+        ];
+    }
+
+    return $results;
+}
+
+function buildStaticLoanDetails(string $startDate, string $endDate): array
+{
+    $disbursements = getStaticDisbursements();
+    $applications = getStaticApplications();
+    $borrowers = getStaticBorrowers();
+    $repayments = getStaticRepayments();
+    $schedules = getStaticPaymentSchedules();
+
+    $applicationIndex = [];
+    foreach ($applications as $application) {
+        if (!isset($application['id'])) {
+            continue;
+        }
+
+        $applicationIndex[(int) $application['id']] = $application;
+    }
+
+    $borrowerIndex = [];
+    foreach ($borrowers as $borrower) {
+        if (!isset($borrower['id'])) {
+            continue;
+        }
+
+        $borrowerIndex[(int) $borrower['id']] = $borrower;
+    }
+
+    $repaymentsByDisbursement = [];
+    foreach ($repayments as $repayment) {
+        if (($repayment['deleted'] ?? 0) === 1 || ($repayment['cheque_dishonour'] ?? '0') === '1') {
+            continue;
+        }
+
+        $disbursementId = (int) ($repayment['disbursement_id'] ?? 0);
+        if ($disbursementId === 0) {
+            continue;
+        }
+
+        if (!isset($repaymentsByDisbursement[$disbursementId])) {
+            $repaymentsByDisbursement[$disbursementId] = [];
+        }
+
+        $repaymentsByDisbursement[$disbursementId][] = $repayment;
+    }
+
+    $scheduleInterestByDisbursement = [];
+    foreach ($schedules as $schedule) {
+        if (($schedule['deleted'] ?? 0) === 1) {
+            continue;
+        }
+
+        $disbursementId = (int) ($schedule['disbursement_id'] ?? 0);
+        if ($disbursementId === 0) {
+            continue;
+        }
+
+        if (!isset($scheduleInterestByDisbursement[$disbursementId])) {
+            $scheduleInterestByDisbursement[$disbursementId] = 0.0;
+        }
+
+        $scheduleInterestByDisbursement[$disbursementId] += (float) ($schedule['interest'] ?? 0.0);
+    }
+
+    $results = [];
+
+    foreach ($disbursements as $disbursement) {
+        $date = $disbursement['date'] ?? null;
+        if ($date === null || $date < $startDate || $date > $endDate) {
+            continue;
+        }
+
+        $applicationId = (int) ($disbursement['application_id'] ?? 0);
+        $application = $applicationIndex[$applicationId] ?? null;
+        if ($application === null || ($application['deleted'] ?? 0) === 1) {
+            continue;
+        }
+
+        $borrowerId = (int) ($application['borrower_id'] ?? 0);
+        $borrower = $borrowerIndex[$borrowerId] ?? [];
+
+        $disbursementId = (int) ($disbursement['id'] ?? 0);
+        $repaymentList = $repaymentsByDisbursement[$disbursementId] ?? [];
+
+        $paidPrincipal = 0.0;
+        $interestCollected = 0.0;
+        $totalRepayments = 0.0;
+        $permitFees = 0.0;
+        $lastPaidDate = null;
+
+        foreach ($repaymentList as $repayment) {
+            $paidPrincipal += (float) ($repayment['principal'] ?? 0.0);
+            $interestCollected += (float) ($repayment['interest'] ?? 0.0);
+            $totalRepayments += (float) ($repayment['amount'] ?? 0.0);
+            $permitFees += (float) ($repayment['legal_fee'] ?? 0.0)
+                + (float) ($repayment['acceptance_fee'] ?? 0.0)
+                + (float) ($repayment['contract_variation_fee'] ?? 0.0)
+                + (float) ($repayment['cheque_dishonoured_fee'] ?? 0.0)
+                + (float) ($repayment['termination_fee'] ?? 0.0)
+                + (float) ($repayment['renewal_fee'] ?? 0.0)
+                + (float) ($repayment['late_fee'] ?? 0.0);
+
+            $datePaid = $repayment['date'] ?? null;
+            if ($datePaid !== null && ($lastPaidDate === null || $datePaid > $lastPaidDate)) {
+                $lastPaidDate = $datePaid;
+            }
+        }
+
+        $scheduledInterest = $scheduleInterestByDisbursement[$disbursementId] ?? 0.0;
+        $loanAmount = (float) ($disbursement['amount'] ?? 0.0);
+        $outstandingPrincipal = $loanAmount - $paidPrincipal;
+        $outstandingInterest = $scheduledInterest - $interestCollected;
+        $profit = $totalRepayments - $loanAmount;
+
+        $results[] = [
+            'disbursement_id' => $disbursementId,
+            'application_id' => $applicationId,
+            'borrower_id' => $borrowerId,
+            'borrower_uid' => $borrower['uid'] ?? null,
+            'borrower_name' => $borrower['name'] ?? 'Unknown borrower',
+            'gender' => $borrower['gender'] ?? null,
+            'dob' => $borrower['dob'] ?? null,
+            'annual_income' => (float) ($borrower['annual_income'] ?? 0.0),
+            'block' => $borrower['blk'] ?? null,
+            'street' => $borrower['street'] ?? null,
+            'unit_no' => $borrower['unit'] ?? null,
+            'building' => $borrower['building'] ?? null,
+            'postal' => $borrower['pincode'] ?? null,
+            'address' => $borrower['address1'] ?? null,
+            'borrower_email' => $borrower['email'] ?? null,
+            'borrower_phone' => $borrower['hand_phone'] ?? null,
+            'account_number' => $disbursement['account_number'] ?? ($application['account_number'] ?? null),
+            'loan_date' => $date,
+            'loan_amount' => $loanAmount,
+            'remarks' => $disbursement['remarks'] ?? null,
+            'status' => $disbursement['status'] ?? null,
+            'tenure' => $disbursement['installment_count'] ?? null,
+            'paid_principal' => $paidPrincipal,
+            'os_principal' => $outstandingPrincipal,
+            'os_interest' => $outstandingInterest,
+            'profit' => $profit,
+            'interest_collected' => $interestCollected,
+            'permit_fee_collected' => $permitFees,
+            'last_paid_date' => $lastPaidDate,
+        ];
+    }
+
+    usort(
+        $results,
+        static function (array $a, array $b): int {
+            if ($a['loan_date'] === $b['loan_date']) {
+                return $b['disbursement_id'] <=> $a['disbursement_id'];
+            }
+
+            return strcmp((string) $b['loan_date'], (string) $a['loan_date']);
+        }
+    );
+
+    return $results;
+}
+
+function formatCurrency(float $amount): string
+{
+    return number_format($amount, 2);
+}
+
+function formatFullAddress(array $row): string
+{
+    $parts = [];
+
+    $block = trim((string) ($row['block'] ?? ''));
+    if ($block !== '') {
+        $parts[] = 'Blk ' . $block;
+    }
+
+    $street = trim((string) ($row['street'] ?? ''));
+    if ($street !== '') {
+        $parts[] = $street;
+    }
+
+    $unit = trim((string) ($row['unit_no'] ?? ''));
+    if ($unit !== '') {
+        $parts[] = str_starts_with($unit, '#') ? $unit : '#' . $unit;
+    }
+
+    $building = trim((string) ($row['building'] ?? ''));
+    if ($building !== '') {
+        $parts[] = $building;
+    }
+
+    $address = trim((string) ($row['address'] ?? ''));
+    if ($address !== '') {
+        $parts[] = $address;
+    }
+
+    $postal = trim((string) ($row['postal'] ?? ''));
+    if ($postal !== '') {
+        $parts[] = 'Postal ' . $postal;
+    }
+
+    return $parts === [] ? '—' : implode(', ', $parts);
+}
+
+function formatNullableDate(?string $date): string
+{
+    if ($date === null || $date === '' || $date === '0000-00-00') {
+        return '—';
+    }
+
+    return formatDisplayDate($date);
+}
+
+function formatDisplayDate(string $date): string
+{
+    $dateTime = DateTimeImmutable::createFromFormat('Y-m-d', $date);
+
+    if ($dateTime === false) {
+        return $date;
+    }
+
+    return $dateTime->format('j M Y');
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Loans Report</title>
+    <style>
+        :root {
+            color-scheme: light;
+            font-family: "Inter", "Segoe UI", Roboto, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+        }
+
+        body {
+            margin: 0;
+            padding: 2.5rem 1.5rem 4rem;
+            background-color: #f5f6fa;
+            color: #1a1a1a;
+        }
+
+        header {
+            max-width: 1200px;
+            margin: 0 auto 2rem;
+        }
+
+        h1 {
+            margin-bottom: 0.5rem;
+            font-size: 2rem;
+        }
+
+        p.subtitle {
+            margin: 0;
+            color: #4a5568;
+        }
+
+        main {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+            padding: 2rem;
+        }
+
+        .report-preview {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1.75rem;
+        }
+
+        .preview-card {
+            border-radius: 12px;
+            padding: 1.25rem 1.5rem;
+            background: linear-gradient(145deg, #2563eb, #1d4ed8);
+            color: #fff;
+            box-shadow: 0 12px 30px rgba(37, 99, 235, 0.25);
+        }
+
+        .preview-card h2 {
+            margin: 0 0 0.25rem;
+            font-size: 0.875rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            opacity: 0.9;
+        }
+
+        .preview-card p {
+            margin: 0;
+            font-size: 1.75rem;
+            font-weight: 700;
+            letter-spacing: -0.01em;
+        }
+
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem 2rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .meta-item {
+            flex: 1 1 200px;
+        }
+
+        .meta-label {
+            display: block;
+            font-size: 0.875rem;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: #64748b;
+            margin-bottom: 0.25rem;
+        }
+
+        .meta-value {
+            font-size: 1.125rem;
+            font-weight: 600;
+        }
+
+        .actions {
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 1.5rem;
+        }
+
+        .actions button {
+            background-color: #2563eb;
+            border: none;
+            color: #fff;
+            font-weight: 600;
+            padding: 0.75rem 1.5rem;
+            border-radius: 999px;
+            cursor: pointer;
+            transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+        }
+
+        .actions button:hover,
+        .actions button:focus {
+            background-color: #1d4ed8;
+            transform: translateY(-1px);
+        }
+
+        .table-container {
+            overflow-x: auto;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            overflow: hidden;
+            border-radius: 12px;
+            min-width: 1200px;
+        }
+
+        thead {
+            background-color: #0f172a;
+            color: #fff;
+        }
+
+        th,
+        td {
+            padding: 0.875rem 1rem;
+            text-align: left;
+        }
+
+        tbody tr:nth-child(odd) {
+            background-color: #f8fafc;
+        }
+
+        tbody tr:hover {
+            background-color: #eff6ff;
+        }
+
+        .numeric {
+            text-align: right;
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+        }
+
+        .text-nowrap {
+            white-space: nowrap;
+        }
+
+        .muted {
+            color: #64748b;
+            font-size: 0.85rem;
+        }
+
+        .cell-primary {
+            font-weight: 600;
+        }
+
+        .cell-secondary {
+            margin-top: 0.25rem;
+            color: #64748b;
+            font-size: 0.85rem;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 3rem 1rem;
+            color: #4a5568;
+        }
+
+        .error-banner {
+            background-color: #fee2e2;
+            color: #b91c1c;
+            border-radius: 8px;
+            padding: 0.75rem 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        @media print {
+            body {
+                background: #fff;
+                padding: 1rem;
+            }
+
+            main {
+                box-shadow: none;
+                padding: 0;
+            }
+
+            .actions {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>All Loans Report</h1>
+    <p class="subtitle">Comprehensive view of loans with borrower contact information.</p>
+</header>
+<main>
+    <?php if ($errorMessage !== null): ?>
+        <div class="error-banner" role="alert">
+            <?php echo htmlspecialchars($errorMessage, ENT_QUOTES); ?> Showing sample data instead.
+        </div>
+    <?php endif; ?>
+
+    <section class="report-preview" aria-label="Report highlights">
+        <article class="preview-card">
+            <h2>Total loan amount</h2>
+            <p>$<?php echo formatCurrency($totalAmount); ?></p>
+        </article>
+        <article class="preview-card">
+            <h2>Principal repaid</h2>
+            <p>$<?php echo formatCurrency($totalPaidPrincipal); ?></p>
+        </article>
+        <article class="preview-card">
+            <h2>Outstanding principal</h2>
+            <p>$<?php echo formatCurrency($totalOutstandingPrincipal); ?></p>
+        </article>
+        <article class="preview-card">
+            <h2>Interest collected</h2>
+            <p>$<?php echo formatCurrency($totalInterestCollected); ?></p>
+        </article>
+    </section>
+
+    <section class="report-meta" aria-label="Report filters">
+        <div class="meta-item">
+            <span class="meta-label">Start date</span>
+            <span class="meta-value"><?php echo htmlspecialchars($startLabel, ENT_QUOTES); ?></span>
+        </div>
+        <div class="meta-item">
+            <span class="meta-label">End date</span>
+            <span class="meta-value"><?php echo htmlspecialchars($endLabel, ENT_QUOTES); ?></span>
+        </div>
+        <div class="meta-item">
+            <span class="meta-label">Loans</span>
+            <span class="meta-value"><?php echo number_format($loanCount); ?></span>
+        </div>
+        <div class="meta-item">
+            <span class="meta-label">Unique borrowers</span>
+            <span class="meta-value"><?php echo number_format($uniqueBorrowers); ?></span>
+        </div>
+        <div class="meta-item">
+            <span class="meta-label">Outstanding interest</span>
+            <span class="meta-value">$<?php echo formatCurrency($totalOutstandingInterest); ?></span>
+        </div>
+        <div class="meta-item">
+            <span class="meta-label">Total profit</span>
+            <span class="meta-value">$<?php echo formatCurrency($totalProfit); ?></span>
+        </div>
+    </section>
+
+    <div class="actions">
+        <button type="button" id="export-pdf">Export to PDF</button>
+    </div>
+
+    <?php if (count($rows) === 0): ?>
+        <div class="empty-state">
+            <p>No loans found for the selected period.</p>
+        </div>
+    <?php else: ?>
+        <div class="table-container">
+            <table>
+                <thead>
+                <tr>
+                    <th scope="col">Borrower</th>
+                    <th scope="col">Contact &amp; address</th>
+                    <th scope="col">Loan details</th>
+                    <th scope="col" class="numeric">Loan amount</th>
+                    <th scope="col" class="numeric">Principal</th>
+                    <th scope="col" class="numeric">Interest</th>
+                    <th scope="col" class="numeric">Fees &amp; profit</th>
+                    <th scope="col" class="text-nowrap">Last payment</th>
+                    <th scope="col">Remarks</th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($rows as $row): ?>
+                    <tr>
+                        <td>
+                            <div class="cell-primary"><?php echo htmlspecialchars($row['borrower_name'], ENT_QUOTES); ?></div>
+                            <div class="cell-secondary">
+                                <?php if (!empty($row['borrower_uid'])): ?>
+                                    UID: <?php echo htmlspecialchars((string) $row['borrower_uid'], ENT_QUOTES); ?>
+                                <?php else: ?>
+                                    <span class="muted">UID unavailable</span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="cell-secondary">
+                                <?php
+                                $demographicPieces = [];
+                                if (isset($row['gender']) && $row['gender'] !== '') {
+                                    $demographicPieces[] = htmlspecialchars((string) $row['gender'], ENT_QUOTES);
+                                }
+                                $dobLabel = formatNullableDate($row['dob']);
+                                if ($dobLabel !== '—') {
+                                    $demographicPieces[] = htmlspecialchars($dobLabel, ENT_QUOTES);
+                                }
+
+                                if ($demographicPieces === []) {
+                                    echo "<span class=\"muted\">No demographic data</span>";
+                                } else {
+                                    echo implode(' • ', $demographicPieces);
+                                }
+                                ?>
+                            </div>
+                            <?php if (($row['annual_income'] ?? 0.0) > 0): ?>
+                                <div class="cell-secondary">Annual income: $<?php echo formatCurrency((float) $row['annual_income']); ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <div class="cell-secondary">
+                                <?php if (!empty($row['borrower_phone'])): ?>
+                                    <?php echo htmlspecialchars((string) $row['borrower_phone'], ENT_QUOTES); ?>
+                                <?php else: ?>
+                                    <span class="muted">No phone on file</span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="cell-secondary">
+                                <?php if (!empty($row['borrower_email'])): ?>
+                                    <?php echo htmlspecialchars((string) $row['borrower_email'], ENT_QUOTES); ?>
+                                <?php else: ?>
+                                    <span class="muted">No email on file</span>
+                                <?php endif; ?>
+                            </div>
+                            <div class="cell-secondary">Address: <?php echo htmlspecialchars(formatFullAddress($row), ENT_QUOTES); ?></div>
+                        </td>
+                        <td>
+                            <div class="cell-secondary">Disbursement #<?php echo htmlspecialchars((string) ($row['disbursement_id'] ?? '—'), ENT_QUOTES); ?></div>
+                            <div class="cell-secondary">Account: <?php echo htmlspecialchars((string) ($row['account_number'] ?? '—'), ENT_QUOTES); ?></div>
+                            <div class="cell-secondary">Loan date: <?php echo htmlspecialchars(formatNullableDate($row['loan_date']), ENT_QUOTES); ?></div>
+                            <div class="cell-secondary">Tenure: <?php echo htmlspecialchars($row['tenure'] !== null ? (string) $row['tenure'] . ' instalments' : '—', ENT_QUOTES); ?></div>
+                            <div class="cell-secondary">Status: <?php echo htmlspecialchars($row['status'] ?? '—', ENT_QUOTES); ?></div>
+                        </td>
+                        <td class="numeric">$<?php echo formatCurrency((float) $row['loan_amount']); ?></td>
+                        <td class="numeric">
+                            <div>Paid: $<?php echo formatCurrency((float) $row['paid_principal']); ?></div>
+                            <div>Outstanding: $<?php echo formatCurrency((float) $row['os_principal']); ?></div>
+                        </td>
+                        <td class="numeric">
+                            <div>Outstanding: $<?php echo formatCurrency((float) $row['os_interest']); ?></div>
+                            <div>Collected: $<?php echo formatCurrency((float) $row['interest_collected']); ?></div>
+                        </td>
+                        <td class="numeric">
+                            <div>Permit fees: $<?php echo formatCurrency((float) $row['permit_fee_collected']); ?></div>
+                            <div>Profit: $<?php echo formatCurrency((float) $row['profit']); ?></div>
+                        </td>
+                        <td class="text-nowrap"><?php echo htmlspecialchars(formatNullableDate($row['last_paid_date']), ENT_QUOTES); ?></td>
+                        <td><?php echo htmlspecialchars($row['remarks'] !== null && $row['remarks'] !== '' ? $row['remarks'] : '—', ENT_QUOTES); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</main>
+<script>
+    document.getElementById('export-pdf')?.addEventListener('click', () => {
+        window.print();
+    });
+</script>
+</body>
+</html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -46,8 +46,11 @@
 
     <template id="report-card-template">
       <a class="report-card" href="#">
-        <h3 class="report-title"></h3>
-        <p class="report-description"></p>
+        <div class="report-card-header">
+          <h3 class="report-title"></h3>
+          <p class="report-description"></p>
+        </div>
+        <ul class="report-metrics" aria-label="Key metrics preview"></ul>
       </a>
     </template>
 

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -161,10 +161,18 @@ button.secondary:hover {
   padding: 1.5rem;
   border: 1px solid color-mix(in srgb, var(--border) 50%, var(--border-dark) 50%);
   box-shadow: 0 22px 52px -32px rgba(15, 23, 42, 0.5);
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   text-decoration: none;
   color: inherit;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.report-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .report-card:hover,
@@ -186,6 +194,39 @@ button.secondary:hover {
 .report-card p {
   margin: 0.5rem 0 0;
   color: var(--text-muted);
+}
+
+.report-metrics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.report-metrics li {
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 60%, var(--border-dark) 40%);
+  padding: 0.75rem 1rem;
+  background: rgba(248, 250, 252, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.report-metric-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.report-metric-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .empty-state,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -138,6 +138,7 @@ function renderReports(reports: ReportDescriptor[]): void {
     const card = instance.querySelector<HTMLAnchorElement>(".report-card");
     const title = instance.querySelector<HTMLHeadingElement>(".report-title");
     const description = instance.querySelector<HTMLParagraphElement>(".report-description");
+    const metricsList = instance.querySelector<HTMLUListElement>(".report-metrics");
 
     if (card) {
       card.href = buildReportLink(report);
@@ -152,6 +153,26 @@ function renderReports(reports: ReportDescriptor[]): void {
     }
     if (title) title.textContent = report.name;
     if (description) description.textContent = report.description;
+    if (metricsList) {
+      const metrics = report.metrics.slice(0, 3);
+      metricsList.innerHTML = "";
+      metrics.forEach((metric) => {
+        const item = document.createElement("li");
+        const label = document.createElement("span");
+        label.className = "report-metric-label";
+        label.textContent = metric.label;
+
+        const value = document.createElement("span");
+        value.className = "report-metric-value";
+        const formatted = typeof metric.formatted === "number" ? metric.formatted.toLocaleString() : String(metric.formatted);
+        value.textContent = formatted;
+
+        item.append(label, value);
+        metricsList.append(item);
+      });
+
+      metricsList.hidden = metrics.length === 0;
+    }
 
     fragment.append(instance);
   });


### PR DESCRIPTION
## Summary
- replace the All Loans report SQL with the disbursement-based query so borrower demographics, repayment totals, and loan metadata are available to the page and metrics API
- expand the report layout to surface repayment highlights and detailed borrower, contact, and financial information in the summary table
- refresh the static dataset helpers to provide disbursement, repayment, borrower, and schedule fields that mirror the live query for offline fallbacks

## Testing
- php -l backend/reports/all-loans-report.php
- php -l backend/api/reports.php
- php -l backend/lib/static_data.php

------
https://chatgpt.com/codex/tasks/task_b_69004877fd64832d86b1eeb30d8a2b5a